### PR TITLE
Feat: pass standard env into pods

### DIFF
--- a/src/services/ManifestParser.ts
+++ b/src/services/ManifestParser.ts
@@ -97,8 +97,6 @@ export class Manifest {
   }
 
   processValue (value: string): string {
-    // TODO: is this the way we want to do escaping?
-    if (value.startsWith('\\$')) return value.substring(1)
     if (!value.startsWith('$')) return value
 
     const varName = value.substring(1)


### PR DESCRIPTION
Causes the host to pass 4 new fields into the contract, via the environment:

- `CODIUS=true` - Allows the container to see whether it's running in codius
- `CODIUS_HOST={ host's public uri }` - The URI of the host on which this contract is running
- `CODIUS_MANIFEST_HASH={ this contract's manifest hash }` - The manifest hash of this contract (base32)
- `CODIUS_MANIFEST={ this contract's manifest }` - The manifest of this contract (stringified JSON)

Note that this also forbids any user-specified environment variables beginning in `CODIUS`, in order to reserve that namespace for any future fields that may be added