### PR TITLE
fix: make /version response consistent with /peers/discover

### DIFF
--- a/src/controllers/version.ts
+++ b/src/controllers/version.ts
@@ -8,8 +8,8 @@ export default function (server: Hapi.Server, deps: Injector) {
 
   async function getVersion (request: Hapi.Request, h: Hapi.ResponseToolkit) {
     return {
-      name: ver.getVersion(),
-      version: ver.getImplementationName()
+      name: ver.getImplementationName(),
+      version: ver.getVersion()
     }
   }
 


### PR DESCRIPTION
The endpoint `/peers/discover` designates `name` and `version` with `getImplementationName()` and `getVersion()` respectively. `/version` has the opposite.