### PR TITLE
fix: still discover old peers

### DIFF
--- a/src/services/PeerFinder.ts
+++ b/src/services/PeerFinder.ts
@@ -32,11 +32,12 @@ export default class PeerFinder {
         const res = await axios.post(peer + '/peers/discover', {
           peers: [ this.identity.getUri() ]
         })
+        log.debug('received %d peers from %s', res.data.peers.length, peer)
         this.peerDb.addPeers(res.data.peers)
           .catch(err => log.error(err))
       } catch (err) {
+        log.error('%s for %s. Removing...', err, peer)
         this.peerDb.removePeer(peer)
-        log.error(err)
       }
     }
     setTimeout(this.run.bind(this), DEFAULT_INTERVAL)


### PR DESCRIPTION
Current master does not pick up old peers since they don't have the `/info` endpoint. We must add them regardless to maintain backward compatibility