### PR TITLE
Add debug mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 /src/**/*.js
 /src/**/*.js.map
 /src/**/*.d.ts
+!/src/typings/*.d.ts
 /test/**/*.js
 /test/**/*.js.map
 /test/**/*.d.ts

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "levelup": "^3.0.1",
     "lodash": "^4.17.10",
     "memdown": "^3.0.0",
+    "multi-read-stream": "^2.0.0",
     "reduct": "^3.2.0",
     "riverpig": "^1.1.3",
     "thirty-two": "^1.0.2",

--- a/src/schemas/Manifest.json
+++ b/src/schemas/Manifest.json
@@ -63,6 +63,9 @@
         "required": [ "value" ],
         "additionalProperties": false
       }
+    },
+    "debug": {
+      "type": "boolean"
     }
   },
   "required": [ "name", "version", "containers" ],

--- a/src/schemas/Manifest.ts
+++ b/src/schemas/Manifest.ts
@@ -24,4 +24,5 @@ export interface Manifest {
       value: string;
     };
   };
+  debug?: boolean;
 }

--- a/src/schemas/PodRequest.json
+++ b/src/schemas/PodRequest.json
@@ -66,6 +66,9 @@
             "required": [ "value" ],
             "additionalProperties": false
           }
+        },
+        "debug": {
+          "type": "boolean"
         }
       },
       "required": [ "name", "version", "containers" ],

--- a/src/schemas/PodRequest.ts
+++ b/src/schemas/PodRequest.ts
@@ -25,6 +25,7 @@ export interface PodRequest {
         value: string;
       };
     };
+    debug?: boolean;
   };
   private?: {
     vars?: {

--- a/src/services/HttpServer.ts
+++ b/src/services/HttpServer.ts
@@ -25,7 +25,16 @@ export default class HttpServer {
     this.server = new Hapi.Server({
       uri: this.config.publicUri.replace(/\/+$/, ''),
       address: this.config.bindIp,
-      port: this.config.port
+      port: this.config.port,
+      mime: {
+        override: {
+          // Streaming responses shouldn't get buffered so for simplicity we'll
+          // just turn off compression for them.
+          'application/vnd.codius.raw-stream': {
+            compressible: false
+          }
+        }
+      }
     })
 
     registerVersionController(this.server, deps)

--- a/src/services/Money.ts
+++ b/src/services/Money.ts
@@ -48,6 +48,8 @@ export default class Money {
           plugin,
           assetCode: info.assetCode,
           assetScale: info.assetScale,
+          sendRoutes: false,
+          receiveRoutes: false,
           options
         },
         child: {

--- a/src/services/PeerFinder.ts
+++ b/src/services/PeerFinder.ts
@@ -34,7 +34,7 @@ export default class PeerFinder {
         })
         log.trace('received %d peers from %s', res.data.peers.length, peer)
         this.peerDb.addPeers(res.data.peers)
-          .catch(err => log.error(err))
+          .catch(err => log.debug(err))
       } catch (err) {
         log.debug('%s for %s. Removing...', err, peer)
         this.peerDb.removePeer(peer)

--- a/src/typings/multi-read-stream.d.ts
+++ b/src/typings/multi-read-stream.d.ts
@@ -1,0 +1,1 @@
+declare module 'multi-read-stream'


### PR DESCRIPTION
Allow pods to be uploaded in "debug mode" as denoted by the `debug` field in the manifest. This enables various debug functionality. Currently, it allows anyone to get the logs from the pod.