### PR TITLE
Fix: move codius-moneyd to docker hub

### DIFF
--- a/src/services/ManifestParser.ts
+++ b/src/services/ManifestParser.ts
@@ -48,7 +48,7 @@ export class Manifest {
         .concat([{
           // Adds interledger access to this pod, listening on 7768
           name: `${this.hash}_moneyd`,
-          image: 'docker.coil.com/codius-moneyd@sha256:4c02fc168e6b4cfde90475ed3c3243de0bce4ca76b73753a92fb74bf5116deef',
+          image: 'codius/codius-moneyd@sha256:4c02fc168e6b4cfde90475ed3c3243de0bce4ca76b73753a92fb74bf5116deef',
           envs: [{ env: 'CODIUS_SECRET', value: this.secret.hmac(this.hash) }]
         }])
     }


### PR DESCRIPTION
We no longer need to worry about having the image be private, so it can be moved to docker hub. This will prevent errors related to outages on our docker registry.