### PR TITLE
Update peers to random set of 1,000 in index.html 

### DIFF
--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -38,6 +38,6 @@
     </tr>
   </table>
   <p>Additional information about this Codius host can be found at these links:</p>
-  <li><a href="/peers">Peers of this host (Random set of 10)</a></li>
+  <li><a href="/peers">Peers of this host (Random set of 1,000)</a></li>
   <li><a href="/version">Current running version of Codius</a></li>
 </html>


### PR DESCRIPTION
The index.html file says a random set of 10 in the /peers endpoint, but there was an update to change this to 1,000. This PR just updates that number on page.