### PR TITLE
feat: stream for keeping connection alive

### DIFF
--- a/src/controllers/pods.ts
+++ b/src/controllers/pods.ts
@@ -116,7 +116,7 @@ export default function (server: Hapi.Server, deps: Injector) {
       clearInterval(streamer)
       res.end()
       log.error('error uploading pod. error=' + e.message)
-      throw Boom.badImplementation('Failed to upload pod.')
+      // throw Boom.badImplementation('Failed to upload pod.')
     }
 
     return h.abandon

--- a/src/controllers/pods.ts
+++ b/src/controllers/pods.ts
@@ -119,7 +119,8 @@ export default function (server: Hapi.Server, deps: Injector) {
     } catch (e) {
       console.log('caught an error at pods')
       clearInterval(streamer)
-      res.statusCode = 500
+      // res.statusCode = 500
+      res.writeHead(500, 'Internal Serve Error')
       // res.setHeader('Content-type', 'application/json')
       res.end(JSON.stringify({ error: 'Internal Server Error' }))
       log.error('error uploading pod. error=' + e.message)

--- a/src/controllers/pods.ts
+++ b/src/controllers/pods.ts
@@ -87,6 +87,8 @@ export default function (server: Hapi.Server, deps: Injector) {
       res.write(' ')
     }, config.timeout)
 
+    console.log(res.headersSent)
+
     let method
     if (request.method === 'post') {
       // throw error if memory usage exceeds available memory
@@ -115,15 +117,31 @@ export default function (server: Hapi.Server, deps: Injector) {
       res.setHeader('Content-type', 'application/json')
       console.log('headers set')
       res.end(JSON.stringify(result))
+      console.log('waiting 5s for proper response')
+      await new Promise(resolve => {
+        setTimeout(() => {
+          console.log('waited for proper response')
+          resolve()
+        }, 5000)
+      })
       console.log('returned response')
     } catch (e) {
       console.log('caught an error at pods')
       clearInterval(streamer)
+      console.log(res.headersSent)
       res.writeHead(500, 'Internal Server Error', { 'Content-type': 'application/json' })
+      console.log(res.headersSent)
       const errRes = { error: 'Internal Server Error' }
       const resJSON = JSON.stringify(errRes)
       console.log('RESJSON: ', resJSON)
       res.end(JSON.stringify({ error: 'Internal Server Error' }))
+      console.log('waiting 5s for error response')
+      await new Promise(resolve => {
+        setTimeout(() => {
+          console.log('waited for error response')
+          resolve()
+        }, 5000)
+      })
       log.error('error uploading pod. error=' + e.message)
     }
 

--- a/src/controllers/pods.ts
+++ b/src/controllers/pods.ts
@@ -141,7 +141,7 @@ export default function (server: Hapi.Server, deps: Injector) {
           resolve()
         }, 5000)
       })
-      res.end(JSON.stringify({ error: 'Internal Server Error' }))      
+      res.end(JSON.stringify({ error: 'Internal Server Error' }))
       log.error('error uploading pod. error=' + e.message)
     }
 

--- a/src/controllers/pods.ts
+++ b/src/controllers/pods.ts
@@ -128,20 +128,20 @@ export default function (server: Hapi.Server, deps: Injector) {
       request.payload['manifest'],
       request.payload['private'] || {}
     )
-
+    console.log('podspec made')
     await podManager.startPod(podSpec, duration,
       request.payload['manifest']['port'])
-
+    console.log('pod started')
     await manifestDatabase.saveManifest(podSpec.id, request.payload['manifest'])
-
+    console.log('manifest saved')
     // return info about running pod to uploader
     const podInfo = podDatabase.getPod(podSpec.id)
-
+    console.log('got PodInfo')
     if (!podInfo) {
       throw Boom.serverUnavailable('pod has stopped. ' +
         `manifestHash=${podSpec.id}`)
     }
-
+    console.log('returning..')
     return {
       url: getPodUrl(podInfo.id),
       manifestHash: podInfo.id,

--- a/src/controllers/pods.ts
+++ b/src/controllers/pods.ts
@@ -109,9 +109,13 @@ export default function (server: Hapi.Server, deps: Injector) {
 
     try {
       const result = await method(request, duration)
+      console.log('result acquired')
       clearInterval(streamer)
+      console.log('interval cleared')
       res.setHeader('Content-type', 'application/json')
+      console.log('headers set')
       res.end(JSON.stringify(result))
+      console.log('returned response')
     } catch (e) {
       console.log('caught an error at pods')
       clearInterval(streamer)

--- a/src/controllers/pods.ts
+++ b/src/controllers/pods.ts
@@ -120,7 +120,8 @@ export default function (server: Hapi.Server, deps: Injector) {
       console.log('caught an error at pods')
       clearInterval(streamer)
       res.writeHead(500, 'Internal Server Error', { 'Content-type': 'application/json' })
-      const resJSON = JSON.stringify({ error: 'Internal Server Error' })
+      const errRes = { error: 'Internal Server Error' }
+      const resJSON = JSON.stringify(errRes)
       console.log('RESJSON: ', resJSON)
       res.end(JSON.stringify({ error: 'Internal Server Error' }))
       log.error('error uploading pod. error=' + e.message)

--- a/src/controllers/pods.ts
+++ b/src/controllers/pods.ts
@@ -98,7 +98,7 @@ export default function (server: Hapi.Server, deps: Injector) {
         throw Boom.serverUnavailable('Memory usage exceeded. Send pod request later.')
       }
       method = postPod
-    } else if (method === 'put') {
+    } else if (request.method === 'put') {
       method = extendPod
     } else {
       log.error('error uploading pod. error=Invalid method')
@@ -119,7 +119,7 @@ export default function (server: Hapi.Server, deps: Injector) {
     } catch (e) {
       console.log('caught an error at pods')
       clearInterval(streamer)
-      res.writeHead(500, 'Internal Server Error', { 'Content-type': 'applicaton/json' })
+      res.writeHead(500, 'Internal Server Error', { 'Content-type': 'application/json' })
       res.end(JSON.stringify({ error: 'Internal Server Error' }))
       log.error('error uploading pod. error=' + e.message)
     }

--- a/src/controllers/pods.ts
+++ b/src/controllers/pods.ts
@@ -83,7 +83,6 @@ export default function (server: Hapi.Server, deps: Injector) {
 
   async function streamPod (request: any, h: Hapi.ResponseToolkit) {
     const res = request.raw.res
-    res.setHeader('Content-type', 'application/json')
     const streamer = setInterval(() => {
       res.write(' ')
     }, config.timeout)
@@ -113,14 +112,14 @@ export default function (server: Hapi.Server, deps: Injector) {
       console.log('result acquired')
       clearInterval(streamer)
       console.log('interval cleared')
+      res.setHeader('Content-type', 'application/json')
       console.log('headers set')
       res.end(JSON.stringify(result))
       console.log('returned response')
     } catch (e) {
       console.log('caught an error at pods')
       clearInterval(streamer)
-      // res.statusCode = 500
-      res.writeHead(500, 'Internal Server Error')
+      res.writeHead(500, 'Internal Server Error', { 'Content-type': 'applicaton/json' })
       res.end(JSON.stringify({ error: 'Internal Server Error' }))
       log.error('error uploading pod. error=' + e.message)
     }

--- a/src/controllers/pods.ts
+++ b/src/controllers/pods.ts
@@ -116,7 +116,6 @@ export default function (server: Hapi.Server, deps: Injector) {
       console.log('interval cleared')
       res.setHeader('Content-type', 'application/json')
       console.log('headers set')
-      res.end(JSON.stringify(result))
       console.log('waiting 5s for proper response')
       await new Promise(resolve => {
         setTimeout(() => {
@@ -124,6 +123,7 @@ export default function (server: Hapi.Server, deps: Injector) {
           resolve()
         }, 5000)
       })
+      res.end(JSON.stringify(result))
       console.log('returned response')
     } catch (e) {
       console.log('caught an error at pods')
@@ -134,7 +134,6 @@ export default function (server: Hapi.Server, deps: Injector) {
       const errRes = { error: 'Internal Server Error' }
       const resJSON = JSON.stringify(errRes)
       console.log('RESJSON: ', resJSON)
-      res.end(JSON.stringify({ error: 'Internal Server Error' }))
       console.log('waiting 5s for error response')
       await new Promise(resolve => {
         setTimeout(() => {
@@ -142,6 +141,7 @@ export default function (server: Hapi.Server, deps: Injector) {
           resolve()
         }, 5000)
       })
+      res.end(JSON.stringify({ error: 'Internal Server Error' }))      
       log.error('error uploading pod. error=' + e.message)
     }
 

--- a/src/controllers/pods.ts
+++ b/src/controllers/pods.ts
@@ -114,9 +114,10 @@ export default function (server: Hapi.Server, deps: Injector) {
       res.end(JSON.stringify(result))
     } catch (e) {
       clearInterval(streamer)
-      res.end()
+      res.statusCode = 500
+      res.setHeader('Content-type', 'application/json')
+      res.end(JSON.stringify({ error: 'Internal Server Error' }))
       log.error('error uploading pod. error=' + e.message)
-      // throw Boom.badImplementation('Failed to upload pod.')
     }
 
     return h.abandon

--- a/src/controllers/pods.ts
+++ b/src/controllers/pods.ts
@@ -120,6 +120,8 @@ export default function (server: Hapi.Server, deps: Injector) {
       console.log('caught an error at pods')
       clearInterval(streamer)
       res.writeHead(500, 'Internal Server Error', { 'Content-type': 'application/json' })
+      const resJSON = JSON.stringify({ error: 'Internal Server Error' })
+      console.log('RESJSON: ', resJSON)
       res.end(JSON.stringify({ error: 'Internal Server Error' }))
       log.error('error uploading pod. error=' + e.message)
     }

--- a/src/controllers/pods.ts
+++ b/src/controllers/pods.ts
@@ -159,15 +159,16 @@ export default function (server: Hapi.Server, deps: Injector) {
     if (!manifestHash) {
       throw Boom.badData('manifestHash must be specified')
     }
-
+    console.log('podspec made')
     await podDatabase.addDurationToPod(manifestHash, duration)
-
+    console.log('added duration')
     const podInfo = podDatabase.getPod(manifestHash)
+    console.log('got pod from db')
     if (!podInfo) {
       throw Boom.serverUnavailable('pod has stopped. ' +
         `manifestHash=${manifestHash}`)
     }
-
+    console.log('returning...')
     return {
       url: getPodUrl(podInfo.id),
       manifestHash: podInfo.id,

--- a/src/controllers/pods.ts
+++ b/src/controllers/pods.ts
@@ -113,6 +113,7 @@ export default function (server: Hapi.Server, deps: Injector) {
       res.setHeader('Content-type', 'application/json')
       res.end(JSON.stringify(result))
     } catch (e) {
+      console.log('caught an error at pods')
       clearInterval(streamer)
       res.statusCode = 500
       // res.setHeader('Content-type', 'application/json')

--- a/src/controllers/pods.ts
+++ b/src/controllers/pods.ts
@@ -115,7 +115,7 @@ export default function (server: Hapi.Server, deps: Injector) {
     } catch (e) {
       clearInterval(streamer)
       res.statusCode = 500
-      res.setHeader('Content-type', 'application/json')
+      // res.setHeader('Content-type', 'application/json')
       res.end(JSON.stringify({ error: 'Internal Server Error' }))
       log.error('error uploading pod. error=' + e.message)
     }

--- a/src/controllers/pods.ts
+++ b/src/controllers/pods.ts
@@ -83,6 +83,7 @@ export default function (server: Hapi.Server, deps: Injector) {
 
   async function streamPod (request: any, h: Hapi.ResponseToolkit) {
     const res = request.raw.res
+    res.setHeader('Content-type', 'application/json')
     const streamer = setInterval(() => {
       res.write(' ')
     }, config.timeout)
@@ -112,7 +113,6 @@ export default function (server: Hapi.Server, deps: Injector) {
       console.log('result acquired')
       clearInterval(streamer)
       console.log('interval cleared')
-      res.setHeader('Content-type', 'application/json')
       console.log('headers set')
       res.end(JSON.stringify(result))
       console.log('returned response')
@@ -121,7 +121,6 @@ export default function (server: Hapi.Server, deps: Injector) {
       clearInterval(streamer)
       // res.statusCode = 500
       res.writeHead(500, 'Internal Server Error')
-      res.setHeader('Content-type', 'application/json')
       res.end(JSON.stringify({ error: 'Internal Server Error' }))
       log.error('error uploading pod. error=' + e.message)
     }

--- a/src/controllers/pods.ts
+++ b/src/controllers/pods.ts
@@ -120,8 +120,8 @@ export default function (server: Hapi.Server, deps: Injector) {
       console.log('caught an error at pods')
       clearInterval(streamer)
       // res.statusCode = 500
-      res.writeHead(500, 'Internal Serve Error')
-      // res.setHeader('Content-type', 'application/json')
+      res.writeHead(500, 'Internal Server Error')
+      res.setHeader('Content-type', 'application/json')
       res.end(JSON.stringify({ error: 'Internal Server Error' }))
       log.error('error uploading pod. error=' + e.message)
     }

--- a/src/controllers/pods.ts
+++ b/src/controllers/pods.ts
@@ -144,7 +144,7 @@ export default function (server: Hapi.Server, deps: Injector) {
       res.end(JSON.stringify({ error: 'Internal Server Error' }))
       log.error('error uploading pod. error=' + e.message)
     }
-
+    console.log('Hapi abandoning res...')
     return h.abandon
   }
 

--- a/src/controllers/pods.ts
+++ b/src/controllers/pods.ts
@@ -114,6 +114,7 @@ export default function (server: Hapi.Server, deps: Injector) {
       res.end(JSON.stringify(result))
     } catch (e) {
       clearInterval(streamer)
+      res.end()
       log.error('error uploading pod. error=' + e.message)
       throw Boom.badImplementation('Failed to upload pod.')
     }

--- a/src/services/Config.ts
+++ b/src/services/Config.ts
@@ -38,6 +38,7 @@ export default class Config {
   readonly hostCurrency: string
   readonly hostAssetScale: number
   hostCostPerMonth: number
+  timeout: number
   readonly adminApi: boolean
   readonly adminPort: number
   readonly disableSelfTest: boolean
@@ -75,6 +76,8 @@ export default class Config {
     this.hostAssetScale = 6
     this.hostCostPerMonth = setPrice()
     this.disableSelfTest = env.CODIUS_DISABLE_SELF_TEST === 'true'
+    this.timeout = Number(env.CODIUS_HOST_TIMEOUT) || 10000
+
     // Admin API Config
     this.adminApi = env.CODIUS_ADMIN_API === 'true'
     this.adminPort = Number(env.CODIUS_ADMIN_PORT) || 3001

--- a/src/services/HyperClient.ts
+++ b/src/services/HyperClient.ts
@@ -127,7 +127,7 @@ export default class HyperClient {
     await new Promise(resolve => {
       console.log('waited 5s to return from hyperclient createpod')
       resolve()
-    })
+    }, 5000)
   }
 
   async startPod (podId: string): Promise<void> {

--- a/src/services/HyperClient.ts
+++ b/src/services/HyperClient.ts
@@ -152,6 +152,7 @@ export default class HyperClient {
       await this.createPod(podSpec).catch(async (err) => {
         console.log('second error hyperclient')
         console.log(err)
+        throw Boom.badImplementation('you failed')
       })
       console.log('hyperclient tried to create again')
     })

--- a/src/services/HyperClient.ts
+++ b/src/services/HyperClient.ts
@@ -154,24 +154,29 @@ export default class HyperClient {
   }
 
   async runPod (podSpec: PodSpec): Promise<void> {
-    await this.createPod(podSpec).catch(async (err) => {
-      console.log('caught an error at hyperclient')
-      log.warn(`pulling images after error="${err.message}"`)
-      await this.pullImages(podSpec)
-      await this.createPod(podSpec).catch(async (err) => {
-        console.log('second error hyperclient')
-        console.log(err)
-        console.log('waiting 5s for second hyper create')
-        await new Promise(resolve => {
-          setTimeout(() => {
-            console.log('waited 5 seconds to fail second create')
-            resolve()
-          })
-        })
-        throw Boom.badImplementation('you failed')
-      })
-      console.log('hyperclient tried to create again')
-    })
+    // await this.createPod(podSpec).catch(async (err) => {
+    try {
+      await this.createPod(podSpec)
+    } catch (e) {
+      console.log(e)
+    }
+    //   console.log('caught an error at hyperclient')
+    //   log.warn(`pulling images after error="${err.message}"`)
+    //   await this.pullImages(podSpec)
+    //   await this.createPod(podSpec).catch(async (err) => {
+    //     console.log('second error hyperclient')
+    //     console.log(err)
+    //     console.log('waiting 5s for second hyper create')
+    //     await new Promise(resolve => {
+    //       setTimeout(() => {
+    //         console.log('waited 5 seconds to fail second create')
+    //         resolve()
+    //       })
+    //     })
+    //     throw Boom.badImplementation('you failed')
+    //   })
+    //   console.log('hyperclient tried to create again')
+    // })
     await this.startPod(podSpec.id)
     console.log('hyperclient ran pod.')
   }

--- a/src/services/HyperClient.ts
+++ b/src/services/HyperClient.ts
@@ -133,6 +133,7 @@ export default class HyperClient {
 
   async runPod (podSpec: PodSpec): Promise<void> {
     await this.createPod(podSpec).catch(async (err) => {
+      console.log('caught an error at hyperclient')
       log.warn(`pulling images after error="${err.message}"`)
       await this.pullImages(podSpec)
       await this.createPod(podSpec)

--- a/src/services/HyperClient.ts
+++ b/src/services/HyperClient.ts
@@ -149,7 +149,11 @@ export default class HyperClient {
       console.log('caught an error at hyperclient')
       log.warn(`pulling images after error="${err.message}"`)
       await this.pullImages(podSpec)
-      await this.createPod(podSpec)
+      await this.createPod(podSpec).catch(async (err) => {
+        console.log('second error hyperclient')
+        console.log(err)
+      })
+      console.log('hyperclient tried to create again')
     })
     await this.startPod(podSpec.id)
     console.log('hyperclient ran pod.')

--- a/src/services/HyperClient.ts
+++ b/src/services/HyperClient.ts
@@ -123,6 +123,11 @@ export default class HyperClient {
       })
       throw Boom.serverUnavailable('Could not create pod: hyper error code=' + res.data.Code)
     }
+    console.log('waiting 5s to return from hyperclient createpod')
+    await new Promise(resolve => {
+      console.log('waited 5s to return from hyperclient createpod')
+      resolve()
+    })
   }
 
   async startPod (podId: string): Promise<void> {

--- a/src/services/HyperClient.ts
+++ b/src/services/HyperClient.ts
@@ -125,9 +125,11 @@ export default class HyperClient {
     }
     console.log('waiting 5s to return from hyperclient createpod')
     await new Promise(resolve => {
-      console.log('waited 5s to return from hyperclient createpod')
-      resolve()
-    }, 5000)
+      setTimeout(() => {
+        console.log('waited 5s to return from hyperclient createpod')
+        resolve()
+      })
+    })
   }
 
   async startPod (podId: string): Promise<void> {

--- a/src/services/HyperClient.ts
+++ b/src/services/HyperClient.ts
@@ -159,6 +159,7 @@ export default class HyperClient {
       await this.createPod(podSpec)
     } catch (e) {
       console.log(e)
+      throw Boom.badImplementation('you failed')
     }
     //   console.log('caught an error at hyperclient')
     //   log.warn(`pulling images after error="${err.message}"`)

--- a/src/services/HyperClient.ts
+++ b/src/services/HyperClient.ts
@@ -115,6 +115,14 @@ export default class HyperClient {
       url: '/pod/create',
       data: podSpec
     })
+    console.log('axios done')
+    console.log('waiting 5s to return from hyperclient createpod')
+    await new Promise(resolve => {
+      setTimeout(() => {
+        console.log('waited 5s to return from hyperclient createpod')
+        resolve()
+      })
+    })
     if (res.data.Code !== 0) {
       console.log('waiting 5s to throw hyperclient')
       await new Promise(resolve => {
@@ -123,13 +131,6 @@ export default class HyperClient {
       })
       throw Boom.serverUnavailable('Could not create pod: hyper error code=' + res.data.Code)
     }
-    console.log('waiting 5s to return from hyperclient createpod')
-    await new Promise(resolve => {
-      setTimeout(() => {
-        console.log('waited 5s to return from hyperclient createpod')
-        resolve()
-      })
-    })
   }
 
   async startPod (podId: string): Promise<void> {

--- a/src/services/HyperClient.ts
+++ b/src/services/HyperClient.ts
@@ -152,6 +152,13 @@ export default class HyperClient {
       await this.createPod(podSpec).catch(async (err) => {
         console.log('second error hyperclient')
         console.log(err)
+        console.log('waiting 5s for second hyper create')
+        await new Promise(resolve => {
+          setTimeout(() => {
+            console.log('waited 5 seconds to fail second create')
+            resolve()
+          })
+        })
         throw Boom.badImplementation('you failed')
       })
       console.log('hyperclient tried to create again')

--- a/src/services/HyperClient.ts
+++ b/src/services/HyperClient.ts
@@ -114,7 +114,7 @@ export default class HyperClient {
       setTimeout(() => {
         console.log('waited 5s to run axios')
         resolve()
-      })
+      }, 5000)
     })
     const res = await axios.request({
       socketPath: this.config.hyperSock,
@@ -128,13 +128,15 @@ export default class HyperClient {
       setTimeout(() => {
         console.log('waited 5s to return from hyperclient createpod')
         resolve()
-      })
+      }, 5000)
     })
     if (res.data.Code !== 0) {
       console.log('waiting 5s to throw hyperclient')
       await new Promise(resolve => {
-        console.log('waited 5s to throw hyperclient')
-        resolve()
+        setTimeout(() => {
+          console.log('waited 5s to throw hyperclient')
+          resolve()
+        }, 5000)
       })
       throw Boom.serverUnavailable('Could not create pod: hyper error code=' + res.data.Code)
     }

--- a/src/services/HyperClient.ts
+++ b/src/services/HyperClient.ts
@@ -139,6 +139,7 @@ export default class HyperClient {
       await this.createPod(podSpec)
     })
     await this.startPod(podSpec.id)
+    console.log('hyperclient ran pod.')
   }
 
   async deletePod (podId: string): Promise<void> {

--- a/src/services/HyperClient.ts
+++ b/src/services/HyperClient.ts
@@ -116,6 +116,11 @@ export default class HyperClient {
       data: podSpec
     })
     if (res.data.Code !== 0) {
+      console.log('waiting 5s to throw hyperclient')
+      await new Promise(resolve => {
+        console.log('waited 5s to throw hyperclient')
+        resolve()
+      })
       throw Boom.serverUnavailable('Could not create pod: hyper error code=' + res.data.Code)
     }
   }

--- a/src/services/HyperClient.ts
+++ b/src/services/HyperClient.ts
@@ -106,7 +106,7 @@ export default class HyperClient {
     log.info(`pulled image=${image} in ${elapsed}ms`)
   }
 
-  async createPod (podSpec: PodSpec): Promise<void> {
+  async createPod (podSpec: PodSpec): Promise<any> {
     if (this.config.noop) return
     log.info('creating pod. id=%s', podSpec.id)
     console.log('waiting 5s to run axios')
@@ -140,6 +140,7 @@ export default class HyperClient {
       })
       throw Boom.serverUnavailable('Could not create pod: hyper error code=' + res.data.Code)
     }
+    return res
   }
 
   async startPod (podId: string): Promise<void> {

--- a/src/services/HyperClient.ts
+++ b/src/services/HyperClient.ts
@@ -109,6 +109,13 @@ export default class HyperClient {
   async createPod (podSpec: PodSpec): Promise<void> {
     if (this.config.noop) return
     log.info('creating pod. id=%s', podSpec.id)
+    console.log('waiting 5s to run axios')
+    await new Promise(resolve => {
+      setTimeout(() => {
+        console.log('waited 5s to run axios')
+        resolve()
+      })
+    })
     const res = await axios.request({
       socketPath: this.config.hyperSock,
       method: 'post',

--- a/src/services/PeerDatabase.ts
+++ b/src/services/PeerDatabase.ts
@@ -58,7 +58,7 @@ export default class PeerDatabase {
           }
         } catch (e) {
           if (process.env.NODE_ENV !== 'test') {
-            log.debug('%s for %s', e, peer + '/info')
+            log.trace('%s for %s', e, peer + '/info')
           }
           if (e.response && e.response.status === 404) {
             this.peers.add(peer)

--- a/src/services/PodManager.ts
+++ b/src/services/PodManager.ts
@@ -119,7 +119,7 @@ export default class PodManager {
       await this.pods.setPodPort(podSpec.id, port)
     }
     console.log('get hyper to run pod...')
-    await this.hyperClient.runPod(podSpec).catch((e) => {
+    await this.hyperClient.runPod(podSpec).catch(async (e) => {
       console.log(e)
       console.log('waiting 5s to throw')
       await new Promise(resolve => {

--- a/src/services/PodManager.ts
+++ b/src/services/PodManager.ts
@@ -121,6 +121,13 @@ export default class PodManager {
     console.log('get hyper to run pod...')
     await this.hyperClient.runPod(podSpec).catch((e) => {
       console.log(e)
+      console.log('waiting 5s to throw')
+      await new Promise(resolve => {
+        setTimeout(() => {
+          console.log('waited to throw')
+          resolve()
+        })
+      })
       throw Boom.conflict('this conflicted')
     })
     console.log('hyper ran pod.')

--- a/src/services/PodManager.ts
+++ b/src/services/PodManager.ts
@@ -128,7 +128,7 @@ export default class PodManager {
         setTimeout(() => {
           console.log('waited to throw')
           resolve()
-        })
+        },5000)
       })
       throw Boom.conflict('this conflicted')
     }

--- a/src/services/PodManager.ts
+++ b/src/services/PodManager.ts
@@ -117,8 +117,9 @@ export default class PodManager {
     if (port && Number(port) > 0) {
       await this.pods.setPodPort(podSpec.id, port)
     }
-
+    console.log('get hyper to run pod...')
     await this.hyperClient.runPod(podSpec)
+    console.log('hyper ran pod.')
 
     const ip = await this.hyper.getPodIP(podSpec.id)
     await this.pods.setPodIP(podSpec.id, ip)

--- a/src/services/PodManager.ts
+++ b/src/services/PodManager.ts
@@ -131,8 +131,7 @@ export default class PodManager {
           })
         })
         throw Boom.conflict('this conflicted')
-      }
-    })
+    }
     console.log('hyper ran pod.')
 
     const ip = await this.hyper.getPodIP(podSpec.id)

--- a/src/services/PodManager.ts
+++ b/src/services/PodManager.ts
@@ -122,15 +122,15 @@ export default class PodManager {
     try {
       await this.hyperClient.runPod(podSpec)
     } catch (e) {
-        console.log(e)
-        console.log('waiting 5s to throw')
-        await new Promise(resolve => {
-          setTimeout(() => {
-            console.log('waited to throw')
-            resolve()
-          })
+      console.log(e)
+      console.log('waiting 5s to throw')
+      await new Promise(resolve => {
+        setTimeout(() => {
+          console.log('waited to throw')
+          resolve()
         })
-        throw Boom.conflict('this conflicted')
+      })
+      throw Boom.conflict('this conflicted')
     }
     console.log('hyper ran pod.')
 

--- a/src/services/PodManager.ts
+++ b/src/services/PodManager.ts
@@ -119,16 +119,19 @@ export default class PodManager {
       await this.pods.setPodPort(podSpec.id, port)
     }
     console.log('get hyper to run pod...')
-    await this.hyperClient.runPod(podSpec).catch(async (e) => {
-      console.log(e)
-      console.log('waiting 5s to throw')
-      await new Promise(resolve => {
-        setTimeout(() => {
-          console.log('waited to throw')
-          resolve()
+    try {
+      await this.hyperClient.runPod(podSpec)
+    } catch (e) {
+        console.log(e)
+        console.log('waiting 5s to throw')
+        await new Promise(resolve => {
+          setTimeout(() => {
+            console.log('waited to throw')
+            resolve()
+          })
         })
-      })
-      throw Boom.conflict('this conflicted')
+        throw Boom.conflict('this conflicted')
+      }
     })
     console.log('hyper ran pod.')
 

--- a/src/services/PodManager.ts
+++ b/src/services/PodManager.ts
@@ -8,6 +8,7 @@ import ManifestDatabase from './ManifestDatabase'
 import { checkMemory } from '../util/podResourceCheck'
 import { Transform, PassThrough } from 'stream'
 import * as multi from 'multi-read-stream'
+import * as Boom from 'boom'
 import {
   block,
   onForward,
@@ -118,7 +119,10 @@ export default class PodManager {
       await this.pods.setPodPort(podSpec.id, port)
     }
     console.log('get hyper to run pod...')
-    await this.hyperClient.runPod(podSpec)
+    await this.hyperClient.runPod(podSpec).catch((e) => {
+      console.log(e)
+      throw Boom.conflict('this conflicted')
+    })
     console.log('hyper ran pod.')
 
     const ip = await this.hyper.getPodIP(podSpec.id)

--- a/src/services/PodManager.ts
+++ b/src/services/PodManager.ts
@@ -122,7 +122,9 @@ export default class PodManager {
     console.log('hyper ran pod.')
 
     const ip = await this.hyper.getPodIP(podSpec.id)
+    console.log('acquired pod IP')
     await this.pods.setPodIP(podSpec.id, ip)
+    console.log('pod IP set')
   }
 
   async getLogStream (podId: string, follow: boolean = false) {


### PR DESCRIPTION
Keeps the connection alive by opening a stream to the client and sending whitespace until the server completes processing the request, as per the suggestion in #95 . Once finished, send the JSON response over the stream and close it. Has been applied to pod uploading and pod extending.

Also open to other solutions, but this seems like the best option to prevent nginx timeouts without having someone modify the nginx timeout values.