### PR TITLE
fix: index formatting

### DIFF
--- a/src/controllers/static.ts
+++ b/src/controllers/static.ts
@@ -4,6 +4,7 @@ import { serverInfo } from '../util/serverInfo'
 import PeerDatabase from '../services/PeerDatabase'
 import PodManager from '../services/PodManager'
 import Config from '../services/Config'
+import Version from '../services/Version'
 import { HostInfo } from '../schemas/HostInfo'
 
 export default function (server: Hapi.Server, deps: Injector) {
@@ -11,9 +12,12 @@ export default function (server: Hapi.Server, deps: Injector) {
   const podManager = deps(PodManager)
 
   const config = deps(Config)
+  const ver = deps(Version)
 
   async function getIndex (request: Hapi.Request, h: Hapi.ResponseToolkit) {
     const hostInfo: HostInfo = serverInfo(config, podManager, peerDb)
+    const freeMemRaw = hostInfo.serverFreeMemory
+    const formatFreeMem = (memory: number) => { return (memory % 1000000) > 0 ? (memory / 1000000).toString() + ' gigabytes' : (memory / 1000).toString() + ' megabytes' }
     return h.view('index', {
       uri: hostInfo.uri,
       numPeers: hostInfo.numPeers,
@@ -22,7 +26,9 @@ export default function (server: Hapi.Server, deps: Injector) {
       avgLoad: hostInfo.avgLoad,
       currency: hostInfo.currency,
       costPerMonth: hostInfo.costPerMonth,
-      fullMem: hostInfo.fullMem
+      fullMem: hostInfo.fullMem,
+      freeMem: freeMemRaw ? formatFreeMem(freeMemRaw) : 'N/A',
+      version: ver.getVersion()
     })
   }
 

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -1,5 +1,5 @@
 <html>
-  <h2 id="header">Codius Host at </h2>
+  <h2 id="header">Codius Host v{{ version }} at {{ uri }}</h2>
   <p>This server is a Codius Host being run with <a href="https://github.com/codius/codiusd">codiusd.</a> If you want to upload a contract to this host, you may do so with the <a href="https://github.com/codius/codius">Codius CLI.</a></p>
   
   <p>For more information on Codius, visit <a href="https://codius.org">codius.org.</a></p>
@@ -33,12 +33,14 @@
       <td id="costPerMonth">{{ costPerMonth }}</td>
     </tr>
     <tr>
+      <td>Free Memory: </td>
+      <td id="memory">{{ freeMem }}</td>
+    </tr>
+    <tr>
       <td>Max Memory Used?</td>
       <td id="fullMem">{{ fullMem }}</td>
     </tr>
   </table>
   <p>Additional information about this Codius host can be found at these links:</p>
   <li><a href="/peers">Peers of this host (Random set of 1,000)</a></li>
-  <li><a href="/version">Current running version of Codius</a></li>
-  <li><a href="/memory">Amount of free memory this host has available</a></li>
 </html>


### PR DESCRIPTION
Makes two changes to the `index.html` page:

* Fixes the URI not displaying at the header and includes version number
* Replaces link to free memory with a formatted field on the index page.