### PR TITLE
Add self testing for contract upload and websockets

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
     },
     "@sinonjs/formatio": {
       "version": "2.0.0",
-      "resolved": "http://registry.npmjs.org/@sinonjs/formatio/-/formatio-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-2.0.0.tgz",
       "integrity": "sha512-ls6CAMA6/5gG+O/IdsBcblvnd8qcO/l1TYoNeAzp3wcISOxlPXQEus0mLcdwazEkWjaBdaJ3TaxmNgCLWwvWzg==",
       "dev": true,
       "requires": {
@@ -63,6 +63,11 @@
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-0.0.30.tgz",
       "integrity": "sha512-orGL5LXERPYsLov6CWs3Fh6203+dXzJkR7OnddIr2514Hsecwc8xRpzCapshBbKFImCsvS/mk6+FWiN5LyZJAQ==",
       "dev": true
+    },
+    "@types/events": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@types/events/-/events-1.2.0.tgz",
+      "integrity": "sha512-KEIlhXnIutzKwRbQkGWb/I4HFqBuUykAdHgDED6xqwXJfONCjF5VoE0cXEiurh3XauygxzeDzgtXUqvLkxFzzA=="
     },
     "@types/fs-extra": {
       "version": "5.0.2",
@@ -208,6 +213,15 @@
       "integrity": "sha512-3+vKJKUglEGebpMd//nTU9Y/tgoagRzV6XDpleoYffjAkCSLGx/IjGqA3mIPgb/xPh17hJtzabFIPLTa0cHFig==",
       "requires": {
         "@types/hapi": "*"
+      }
+    },
+    "@types/ws": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-5.1.2.tgz",
+      "integrity": "sha512-NkTXUKTYdXdnPE2aUUbGOXE1XfMK527SCvU/9bj86kyFF6kZ9ZnOQ3mK5jADn98Y2vEUD/7wKDgZa7Qst2wYOg==",
+      "requires": {
+        "@types/events": "*",
+        "@types/node": "*"
       }
     },
     "abstract-leveldown": {
@@ -1415,6 +1429,68 @@
         }
       }
     },
+    "ilp-fetch": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/ilp-fetch/-/ilp-fetch-1.3.7.tgz",
+      "integrity": "sha512-C8HW/WRooVCORWg+H4xym8YQ/lp3YQtK/gqU/VHnxSQrJgKVZpH9wiy5SurncG/0Phpyft9gfdSp00ChAwfPIA==",
+      "requires": {
+        "bignumber.js": "^5.0.0",
+        "ilp-logger": "^1.0.0",
+        "ilp-plugin": "^3.1.1",
+        "ilp-protocol-psk2": "^0.3.1",
+        "ilp-protocol-stream": "^1.4.0",
+        "node-fetch": "^2.1.2"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "9.6.23",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.23.tgz",
+          "integrity": "sha512-d2SJJpwkiPudEQ3+9ysANN2Nvz4QJKUPoe/WL5zyQzI0RaEeZWH5K5xjvUIGszTItHQpFPdH+u51f6G/LkS8Cg=="
+        },
+        "bignumber.js": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-5.0.0.tgz",
+          "integrity": "sha512-KWTu6ZMVk9sxlDJQh2YH1UOnfDP8O8TpxUxgQG/vKASoSnEjK9aVuOueFaPcQEYQ5fyNXNTOYwYw3099RYebWg=="
+        },
+        "ilp-protocol-stream": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/ilp-protocol-stream/-/ilp-protocol-stream-1.4.0.tgz",
+          "integrity": "sha512-GEbyaDGrbhv+O5Y1ZU45jTwUG/PLBTd4u7u6Py4M+tQWC6r0om7sSrMbV4AHXCLUqVLI5PrUUIM1TKKSkXxakg==",
+          "requires": {
+            "@types/node": "^9.6.17",
+            "bignumber.js": "^6.0.0",
+            "debug": "^3.1.0",
+            "ilp-logger": "^1.0.1",
+            "ilp-packet": "^2.2.0",
+            "ilp-protocol-ildcp": "^1.0.0",
+            "oer-utils": "^2.0.1",
+            "source-map-support": "^0.5.6"
+          },
+          "dependencies": {
+            "bignumber.js": {
+              "version": "6.0.0",
+              "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-6.0.0.tgz",
+              "integrity": "sha512-x247jIuy60/+FtMRvscqfxtVHQf8AGx2hm9c6btkgC0x/hp9yt+teISNhvF8WlwRkCc5yF2fDECH8SIMe8j+GA=="
+            }
+          }
+        },
+        "oer-utils": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/oer-utils/-/oer-utils-2.0.1.tgz",
+          "integrity": "sha512-9m3lctkkc/hofsfw76ZQrsIQmenQcC8MggqRP3aPdImYBObywZUCIEXcXAzekas5UpwMAdy7WT0/aHLoDo8PcQ==",
+          "requires": {
+            "bignumber.js": "^6.0.0"
+          },
+          "dependencies": {
+            "bignumber.js": {
+              "version": "6.0.0",
+              "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-6.0.0.tgz",
+              "integrity": "sha512-x247jIuy60/+FtMRvscqfxtVHQf8AGx2hm9c6btkgC0x/hp9yt+teISNhvF8WlwRkCc5yF2fDECH8SIMe8j+GA=="
+            }
+          }
+        }
+      }
+    },
     "ilp-logger": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/ilp-logger/-/ilp-logger-1.0.1.tgz",
@@ -1458,6 +1534,18 @@
         "debug": "^3.1.0",
         "eventemitter2": "^5.0.0",
         "ws": "^3.3.3"
+      },
+      "dependencies": {
+        "ws": {
+          "version": "3.3.3",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-3.3.3.tgz",
+          "integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
+          "requires": {
+            "async-limiter": "~1.0.0",
+            "safe-buffer": "~5.1.0",
+            "ultron": "~1.1.0"
+          }
+        }
       }
     },
     "ilp-plugin-mini-accounts": {
@@ -1475,6 +1563,18 @@
         "ilp-store-wrapper": "^1.0.0",
         "int64": "0.0.5",
         "ws": "^3.3.0"
+      },
+      "dependencies": {
+        "ws": {
+          "version": "3.3.3",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-3.3.3.tgz",
+          "integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
+          "requires": {
+            "async-limiter": "~1.0.0",
+            "safe-buffer": "~5.1.0",
+            "ultron": "~1.1.0"
+          }
+        }
       }
     },
     "ilp-plugin-mini-balances": {
@@ -1504,6 +1604,27 @@
       "requires": {
         "ilp-packet": "^2.1.2",
         "oer-utils": "^1.3.4"
+      }
+    },
+    "ilp-protocol-psk2": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/ilp-protocol-psk2/-/ilp-protocol-psk2-0.3.1.tgz",
+      "integrity": "sha512-CD72tcVhBU1alcFc/NQOIfcZw7sFsEtofvAVyI2cSw91m5yv+8Z1/mxeaua9soNExucEoiIur5Cg0ZWaJrmFWQ==",
+      "requires": {
+        "bignumber.js": "^5.0.0",
+        "debug": "^3.1.0",
+        "ilp-compat-plugin": "^2.0.3",
+        "ilp-packet": "^2.1.2",
+        "ilp-protocol-ildcp": "^1.0.0",
+        "long": "^3.2.0",
+        "oer-utils": "^1.3.2"
+      },
+      "dependencies": {
+        "bignumber.js": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-5.0.0.tgz",
+          "integrity": "sha512-KWTu6ZMVk9sxlDJQh2YH1UOnfDP8O8TpxUxgQG/vKASoSnEjK9aVuOueFaPcQEYQ5fyNXNTOYwYw3099RYebWg=="
+        }
       }
     },
     "ilp-protocol-stream": {
@@ -6332,13 +6453,11 @@
       }
     },
     "ws": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-3.3.3.tgz",
-      "integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-5.2.2.tgz",
+      "integrity": "sha512-jaHFD6PFv6UgoIVda6qZllptQsMlDEJkTQcybzzXDYM1XO9Y8em691FGMPmM46WGyLU4z9KMgQN+qrux/nhlHA==",
       "requires": {
-        "async-limiter": "~1.0.0",
-        "safe-buffer": "~5.1.0",
-        "ultron": "~1.1.0"
+        "async-limiter": "~1.0.0"
       }
     },
     "xtend": {

--- a/package.json
+++ b/package.json
@@ -46,8 +46,9 @@
     "@sharafian/cog": "0.0.5",
     "@types/handlebars": "^4.0.38",
     "@types/inert": "^5.1.1",
-    "axios": "^0.18.0",
     "@types/vision": "^5.3.4",
+    "@types/ws": "^5.1.2",
+    "axios": "^0.18.0",
     "bignumber.js": "^7.2.1",
     "canonical-json": "0.0.4",
     "debug": "^3.1.0",
@@ -59,6 +60,7 @@
     "hapi": "^17.4.0",
     "http-proxy": "^1.17.0",
     "ilp-connector": "^21.3.2",
+    "ilp-fetch": "^1.3.7",
     "ilp-plugin": "^3.1.1",
     "ilp-plugin-mini-balances": "^1.0.3",
     "ilp-protocol-ildcp": "^1.0.0",
@@ -72,7 +74,8 @@
     "thirty-two": "^1.0.2",
     "through2": "^2.0.3",
     "vision": "^5.3.3",
-    "whatwg-fetch": "^2.0.4"
+    "whatwg-fetch": "^2.0.4",
+    "ws": "^5.2.2"
   },
   "devDependencies": {
     "@types/boom": "^7.2.0",

--- a/src/services/App.ts
+++ b/src/services/App.ts
@@ -8,6 +8,7 @@ import AdminServer from './AdminServer'
 import BackgroundValidatePeers from './BackgroundValidatePeers'
 import Secret from './Secret'
 import Money from './Money'
+import SelfTest from './SelfTest'
 
 import { create as createLogger } from '../common/log'
 const log = createLogger('App')
@@ -21,7 +22,7 @@ export default class App {
   private secret: Secret
   private money: Money
   private backgroundValidatePeers: BackgroundValidatePeers
-
+  private selfTest: SelfTest
   constructor (deps: Injector) {
     this.config = deps(Config)
 
@@ -34,6 +35,7 @@ export default class App {
     this.secret = deps(Secret)
     this.money = deps(Money)
     this.backgroundValidatePeers = deps(BackgroundValidatePeers)
+    this.selfTest = deps(SelfTest)
   }
 
   async start () {
@@ -49,6 +51,7 @@ export default class App {
     this.peerFinder.start()
     this.podManager.start()
     this.backgroundValidatePeers.start()
+    this.selfTest.start()
   }
 
   private makeRootDir () {

--- a/src/services/Config.ts
+++ b/src/services/Config.ts
@@ -40,6 +40,7 @@ export default class Config {
   hostCostPerMonth: number
   readonly adminApi: boolean
   readonly adminPort: number
+  readonly disableSelfTest: boolean
 
   constructor (env: Injector | { [k: string]: string | undefined }) {
     // Load config from environment by default
@@ -73,7 +74,7 @@ export default class Config {
     this.hostCurrency = 'XRP'
     this.hostAssetScale = 6
     this.hostCostPerMonth = setPrice()
-
+    this.disableSelfTest = env.CODIUS_DISABLE_SELF_TEST === 'true'
     // Admin API Config
     this.adminApi = env.CODIUS_ADMIN_API === 'true'
     this.adminPort = Number(env.CODIUS_ADMIN_PORT) || 3001

--- a/src/services/SelfTest.ts
+++ b/src/services/SelfTest.ts
@@ -1,0 +1,124 @@
+
+import { Injector } from 'reduct'
+import Config from './Config'
+import { create as createLogger } from '../common/log'
+const ilpFetch = require('ilp-fetch')
+const log = createLogger('SelfTest')
+import * as WebSocket from 'ws'
+const manifestJson = require('../util/self-test-manifest.json')
+import axios from 'axios'
+import * as crypto from 'crypto'
+export default class SelfTest {
+  private config: Config
+  constructor (deps: Injector) {
+    this.config = deps(Config)
+  }
+
+  start () {
+    if (!this.config.disableSelfTest) {
+      this.run()
+      .catch(err => log.error(err))
+    } else {
+      log.debug('Skipping self test')
+    }
+  }
+
+  async run () {
+    const duration = 300
+    const host = this.config.publicUri
+    try {
+      const randomName = crypto.randomBytes(20).toString('hex')
+      manifestJson['manifest']['name'] = randomName
+      log.debug('manifestJson', manifestJson)
+      let response = await ilpFetch(`${host}/pods?duration=${duration}`, {
+        headers: {
+          Accept: `application/codius-v1+json`,
+          'Content-Type': 'application/json'
+        },
+        maxPrice: (this.config.hostCostPerMonth * Math.pow(10, this.config.hostAssetScale)).toString(),
+        method: 'POST',
+        body: JSON.stringify(manifestJson),
+        timeout: 70000 // 1m10s
+      })
+      log.trace('ilpFetch Resp', response)
+      if (this.checkStatus(response)) {
+        // Maybe check status in 30 seconds interval twice.
+        response = await response.json()
+        const url = new URL(this.config.publicUri)
+        await new Promise((resolve, reject) => {
+          setTimeout(() => {
+            resolve()
+          }, 10000)
+        })
+        const webSocketPromise = new Promise(resolve => {
+          const ws = new WebSocket(`wss://${response.manifestHash}.${url.host}`)
+          ws.on('open', () => {
+            log.debug('Web sockets are enabled')
+          })
+
+          ws.on('message', (message: string) => {
+            let finalMessage = JSON.parse(message)
+            if (finalMessage.websocketEnabled) {
+              resolve()
+            }
+          })
+
+          ws.on('error', (err: any) => {
+            log.error('Error on connection for websockets', err)
+            process.exit(1)
+          })
+        })
+
+        const serverPromise = new Promise(async resolve => {
+          try {
+            const serverRes = await axios.get(`https://${response.manifestHash}.${url.host}`)
+            const serverCheck = serverRes.data
+            log.debug('Pod upload succeeded', serverCheck)
+            if (serverCheck.imageUploaded) {
+              // resolve promise
+              resolve()
+            }
+          } catch (err) {
+            log.error('Test contract not running', err)
+            process.exit(1)
+          }
+        })
+        const testPromises = await Promise.all([serverPromise, webSocketPromise])
+          // Test that none of these promises are hanging for more than 60 seconds
+          // Timeout is set so that the contract has time to be pulled.
+        Promise.race([
+          testPromises,
+          new Promise((resolve, reject) => {
+            let timeout = setTimeout(function () {
+              clearTimeout(timeout)
+              reject(new Error('Could not listen to server or websocket due to timeout'))
+            }, 60000)
+          })
+        ])
+        .then(() => {
+          log.info('Codius host passed self test! Ready to accept contracts')
+        })
+        .catch(err => {
+          log.error('Error occurred when accessing self-test contract ', err)
+          process.exit(1)
+        })
+      } else {
+        log.error(`Failed to upload contract due to: ${response.error}`)
+        throw new Error(`Could not upload contract successfully due to: ${response.error}`)
+      }
+    } catch (err) {
+      log.error('Upload Error', err)
+      process.exit(1)
+    }
+  }
+
+  checkStatus (response: any) {
+    if (response && response.status) {
+      const statusString = `${response.status}`
+      if (statusString.startsWith('2')) {
+        return true
+      }
+    }
+    return false
+  }
+}

--- a/src/util/self-test-manifest.json
+++ b/src/util/self-test-manifest.json
@@ -1,0 +1,21 @@
+{
+  "manifest": {
+    "name": "Codius Test 200",
+    "version": "1.0.0",
+    "machine": "small",
+    "port": "3000",
+    "containers": [
+      {
+        "id": "codius-test",
+        "image": "androswong418/codius-test-image@sha256:a92053f78be2e51c47829336d7059a6994b8f27dc41c1441f98caba67439bf45",
+        "environment": {
+          "PORT": "3000"
+        }
+      }
+    ]
+  },
+  "private": {}
+}
+
+
+


### PR DESCRIPTION
This adds self testing by attempting to upload a simple nginx contract which has a /server endpoint for a server and a /websockets endpoint for a websocket connection. By default if the server response returns something incorrectly or a websocket connection fails the codius instance will be shut down. However if CODIUS_DISABLE_SELF_TEST is set to true then the server will continue running.