### PR TITLE
fix: improve self test & report results

### DIFF
--- a/src/schemas/HostInfo.json
+++ b/src/schemas/HostInfo.json
@@ -39,6 +39,9 @@
           "items": {
               "type": "string"
            }
+      },
+      "selfTestSuccess": {
+        "type": "boolean"
       }
   },
   "required": [ "fullMem", "acceptingUploads", "numPeers", "currency", "costPerMonth", "uri" ],

--- a/src/schemas/HostInfo.ts
+++ b/src/schemas/HostInfo.ts
@@ -17,4 +17,5 @@ export interface HostInfo {
   uri: string;
   runningContracts?: number;
   peers?: string[];
+  selfTestSuccess?: boolean;
 }

--- a/src/services/App.ts
+++ b/src/services/App.ts
@@ -48,10 +48,10 @@ export default class App {
     if (this.config.adminApi) {
       await this.adminServer.start()
     }
-    this.peerFinder.start()
     this.podManager.start()
-    this.backgroundValidatePeers.start()
     this.selfTest.start()
+    this.peerFinder.start()
+    this.backgroundValidatePeers.start()
   }
 
   private makeRootDir () {

--- a/src/services/Config.ts
+++ b/src/services/Config.ts
@@ -41,6 +41,7 @@ export default class Config {
   readonly adminApi: boolean
   readonly adminPort: number
   readonly disableSelfTest: boolean
+  selfTestSuccess: boolean
 
   constructor (env: Injector | { [k: string]: string | undefined }) {
     // Load config from environment by default
@@ -75,6 +76,7 @@ export default class Config {
     this.hostAssetScale = 6
     this.hostCostPerMonth = setPrice()
     this.disableSelfTest = env.CODIUS_DISABLE_SELF_TEST === 'true'
+    this.selfTestSuccess = false
     // Admin API Config
     this.adminApi = env.CODIUS_ADMIN_API === 'true'
     this.adminPort = Number(env.CODIUS_ADMIN_PORT) || 3001

--- a/src/services/PeerDatabase.ts
+++ b/src/services/PeerDatabase.ts
@@ -58,7 +58,7 @@ export default class PeerDatabase {
           }
         } catch (e) {
           if (process.env.NODE_ENV !== 'test') {
-            log.debug('%s for %s', e, peer + '/info')
+            log.trace('%s for %s', e, peer + '/info')
           }
           if (e.response && e.response.status === 404) {
             this.peers.add(peer)

--- a/src/services/PeerFinder.ts
+++ b/src/services/PeerFinder.ts
@@ -1,4 +1,5 @@
 import { Injector } from 'reduct'
+import Config from './Config'
 import PeerDatabase from './PeerDatabase'
 import Identity from './Identity'
 import { sampleSize } from 'lodash'
@@ -12,10 +13,12 @@ const PEERS_PER_QUERY = 5
 export default class PeerFinder {
   private peerDb: PeerDatabase
   private identity: Identity
+  private config: Config
 
   constructor (deps: Injector) {
     this.peerDb = deps(PeerDatabase)
     this.identity = deps(Identity)
+    this.config = deps(Config)
   }
 
   start () {
@@ -24,20 +27,22 @@ export default class PeerFinder {
   }
 
   async run () {
-    log.debug('searching peers')
-    const queryPeers = sampleSize(this.peerDb.getPeers(), PEERS_PER_QUERY)
-    log.trace('peers', queryPeers)
-    for (const peer of queryPeers) {
-      try {
-        const res = await axios.post(peer + '/peers/discover', {
-          peers: [ this.identity.getUri() ]
-        })
-        log.trace('received %d peers from %s', res.data.peers.length, peer)
-        this.peerDb.addPeers(res.data.peers)
-          .catch(err => log.debug(err))
-      } catch (err) {
-        log.debug('%s for %s. Removing...', err, peer)
-        this.peerDb.removePeer(peer)
+    if (this.config.selfTestSuccess) {
+      log.debug('searching peers')
+      const queryPeers = sampleSize(this.peerDb.getPeers(), PEERS_PER_QUERY)
+      log.trace('peers', queryPeers)
+      for (const peer of queryPeers) {
+        try {
+          const res = await axios.post(peer + '/peers/discover', {
+            peers: [ this.identity.getUri() ]
+          })
+          log.trace('received %d peers from %s', res.data.peers.length, peer)
+          this.peerDb.addPeers(res.data.peers)
+            .catch(err => log.debug(err))
+        } catch (err) {
+          log.debug('%s for %s. Removing...', err, peer)
+          this.peerDb.removePeer(peer)
+        }
       }
     }
     setTimeout(this.run.bind(this), DEFAULT_INTERVAL)

--- a/src/util/serverInfo.ts
+++ b/src/util/serverInfo.ts
@@ -22,7 +22,8 @@ export function serverInfo (config: Config, podManager: PodManager, peerDb: Peer
     numPeers: peerDb.getNumPeers(),
     currency: config.hostCurrency,
     costPerMonth: config.hostCostPerMonth,
-    uri: config.publicUri
+    uri: config.publicUri,
+    selfTestSuccess: config.selfTestSuccess
   }
 
   return infoResp

--- a/test/api.test.ts
+++ b/test/api.test.ts
@@ -26,7 +26,7 @@ describe('Host info API testing', () => {
       server.inject(request).then(response => {
         const res = JSON.parse(response.payload)
         assert.isOk(res, 'Returns object')
-        assert.hasAllKeys(res, ['fullMem', 'acceptingUploads', 'serverFreeMemory', 'serverUptime', 'serviceUptime', 'avgLoad', 'numPeers', 'currency', 'costPerMonth', 'uri', 'runningContracts'])
+        assert.hasAllKeys(res, ['fullMem', 'acceptingUploads', 'serverFreeMemory', 'serverUptime', 'serviceUptime', 'avgLoad', 'numPeers', 'currency', 'costPerMonth', 'uri', 'runningContracts', 'selfTestSuccess'])
         done()
       }).catch(err => {
         console.log('error message: ', err)


### PR DESCRIPTION
Several improvements are made to the Self Test as per #93 :
* Retries the test 5 times in case a downstream proxy needs time to update the server status.
* Saves the results of the test to the config, where it can be referenced in the host info.
* Prevents peer broadcast & discovery of the host while self tests are unfinished/unsuccessful.