### PR TITLE
feat: unlisted pod support

### DIFF
--- a/src/controllers/pods.ts
+++ b/src/controllers/pods.ts
@@ -153,6 +153,11 @@ export default function (server: Hapi.Server, deps: Injector) {
         `manifestHash=${manifestHash}`)
     }
 
+    if (manifest.privateManifest) {
+      throw Boom.serverUnavailable('attempted to get private pod. ' +
+        `manifestHash=${manifestHash}`)
+    }
+
     return {
       url: getPodUrl(podInfo.id),
       manifestHash: podInfo.id,
@@ -202,6 +207,10 @@ export default function (server: Hapi.Server, deps: Injector) {
       .header('Content-Type', 'application/vnd.codius.raw-stream')
       .header('Connection', 'keep-alive')
       .header('Cache-Control', 'no-cache')
+  }
+
+  async function getAllPods (request: Hapi.Request, h: Hapi.ResponseToolkit) {
+    return podDatabase.getPublicRunningPods()
   }
 
   server.route({
@@ -268,5 +277,11 @@ export default function (server: Hapi.Server, deps: Injector) {
     method: 'GET',
     path: '/pods/{id}/logs',
     handler: getPodLogs
+  })
+
+  server.route({
+    method: 'GET',
+    path: '/pods/all',
+    handler: getAllPods
   })
 }

--- a/src/schemas/Manifest.json
+++ b/src/schemas/Manifest.json
@@ -66,6 +66,12 @@
     },
     "debug": {
       "type": "boolean"
+    },
+    "unlisted": {
+      "type": "boolean"
+    },
+    "privateManifest": {
+      "type": "boolean"
     }
   },
   "required": [ "name", "version", "containers" ],

--- a/src/schemas/Manifest.ts
+++ b/src/schemas/Manifest.ts
@@ -25,4 +25,6 @@ export interface Manifest {
     };
   };
   debug?: boolean;
+  unlisted?: boolean;
+  privateManifest?: boolean;
 }

--- a/src/schemas/PodInfo.json
+++ b/src/schemas/PodInfo.json
@@ -24,6 +24,9 @@
     },
     "totalUptime": {
       "type": "number"
+    },
+    "unlisted": {
+      "type": "boolean"
     }
   },
   "required": [ "id", "running", "start", "expiry", "totalUptime" ],

--- a/src/schemas/PodInfo.ts
+++ b/src/schemas/PodInfo.ts
@@ -13,4 +13,5 @@ export interface PodInfo {
   ip?: string;
   memory?: number;
   totalUptime: number;
+  unlisted?: boolean;
 }

--- a/src/schemas/PodSpec.json
+++ b/src/schemas/PodSpec.json
@@ -23,8 +23,12 @@
         "$ref": "./ContainerSpec.json"
       },
       "minItems": 1
+    },
+    "unlisted": {
+      "type": "boolean",
+      "required": true
     }
   },
-  "required": [ "id", "containers" ],
+  "required": [ "id", "containers", "unlisted" ],
   "additionalProperties": false
 }

--- a/src/schemas/PodSpec.ts
+++ b/src/schemas/PodSpec.ts
@@ -20,4 +20,5 @@ export interface PodSpec {
       value?: string;
     }[];
   }[];
+  unlisted: boolean;
 }

--- a/src/services/ManifestParser.ts
+++ b/src/services/ManifestParser.ts
@@ -50,7 +50,8 @@ export class Manifest {
           name: `${this.hash}_moneyd`,
           image: 'codius/codius-moneyd@sha256:4c02fc168e6b4cfde90475ed3c3243de0bce4ca76b73753a92fb74bf5116deef',
           envs: [{ env: 'CODIUS_SECRET', value: this.secret.hmac(this.hash) }]
-        }])
+        }]),
+      unlisted: this.manifest['unlisted'] || false
     }
   }
 

--- a/src/services/PodDatabase.ts
+++ b/src/services/PodDatabase.ts
@@ -16,7 +16,8 @@ export interface AddPodParams {
   id: string,
   running: boolean,
   duration: string,
-  memory: number
+  memory: number,
+  unlisted: boolean
 }
 
 export default class PodDatabase {
@@ -55,6 +56,13 @@ export default class PodDatabase {
   public getRunningPods (): Array<string> {
     return Array.from(this.pods.values())
       .filter(p => p.running)
+      .map(p => p.id)
+  }
+
+  public getPublicRunningPods (): Array<string> {
+    return Array.from(this.pods.values())
+      .filter(p => p.running)
+      .filter(p => !p.unlisted)
       .map(p => p.id)
   }
 
@@ -112,7 +120,8 @@ export default class PodDatabase {
       start: new Date().toISOString(),
       expiry: addDuration(params.duration),
       memory: params.memory,
-      totalUptime: uptime
+      totalUptime: uptime,
+      unlisted: params.unlisted
     }
 
     this.pods.set(info.id, info)

--- a/src/services/PodManager.ts
+++ b/src/services/PodManager.ts
@@ -112,7 +112,8 @@ export default class PodManager {
         id: podSpec.id,
         running: true,
         duration,
-        memory: checkMemory(podSpec.resource)
+        memory: checkMemory(podSpec.resource),
+        unlisted: podSpec.unlisted
       })
 
       // TODO: validate regex on port arg incoming


### PR DESCRIPTION
This PR allows running pods to be listed by manifest in `GET /pods/all`. It also allows pods that have had `unlisted: true` specified in their manifest to not be listed in this endpoint. The admin endpoint will still display them. Implements #82. 