### PR TITLE
Cleanup and fix index memory line

### DIFF
--- a/src/controllers/static.ts
+++ b/src/controllers/static.ts
@@ -17,7 +17,7 @@ export default function (server: Hapi.Server, deps: Injector) {
   async function getIndex (request: Hapi.Request, h: Hapi.ResponseToolkit) {
     const hostInfo: HostInfo = serverInfo(config, podManager, peerDb)
     const freeMemRaw = hostInfo.serverFreeMemory
-    const formatFreeMem = (memory: number) => { return (memory % 1000000) > 0 ? (memory / 1000000).toString() + ' gigabytes' : (memory / 1000).toString() + ' megabytes' }
+    const formatFreeMem = (memory: number) => { return (Math.floor(memory / 1e9)) > 0 ? ((memory / 1000000000).toFixed(3)).toString() + ' gigabytes' : ((memory / 1000000).toFixed(3)).toString() + ' megabytes' }
     return h.view('index', {
       uri: hostInfo.uri,
       numPeers: hostInfo.numPeers,


### PR DESCRIPTION
Currently, the index line has a few problems:

* It doesn't divide correctly. For example https://codius.sneakyfish5.xyz shows 3457.65494784 gigabytes when it should be 3.45765494784 gigabytes. I also changed it to divide by 1024^3 and 1024^2 for gigabits and megabits respectively to be more accurate in the calculations.
* Even if you have megabytes of free memory, it will still say gigabytes. This should fix that as well.
* Lastly, changed name from `gigabytes` and `megabytes` to `gigabits` and `megabits` to be more accurate as well. 

I also made a change to limit the decimals so that it's a little bit more readable and clean. If someone needs to get the full free memory, they can grab it from /memory endpoint.