### PR TITLE
Make uptime stats more human readable in index page

### DIFF
--- a/src/controllers/static.ts
+++ b/src/controllers/static.ts
@@ -14,6 +14,35 @@ export default function (server: Hapi.Server, deps: Injector) {
   const config = deps(Config)
   const ver = deps(Version)
 
+  function uptimeToStr (uptime: any) {
+
+    function numberEnding (time: any) {
+      return (time > 1 || time === 0) ? `s` : ``
+    }
+
+    const years = Math.floor(uptime / 31536000)
+    const months = Math.floor((uptime %= 31536000) / 2592000)
+    const days = Math.floor((uptime %= 2592000) / 86400)
+    const hours = Math.floor((uptime %= 86400) / 3600)
+    const minutes = Math.floor((uptime %= 3600) / 60)
+    const seconds = Math.floor(uptime % 60)
+
+    if (years) {
+      return `${years} year${numberEnding(years)} ${months} month${numberEnding(months)} ${days} day${numberEnding(days)}`
+    } else if (months) {
+      return `${months} month${numberEnding(months)} ${days} day${numberEnding(days)}`
+    } else if (days) {
+      return `${days} day${numberEnding(days)} ${hours} hour${numberEnding(hours)}`
+    } else if (hours) {
+      return `${hours} hour${numberEnding(hours)} ${minutes} minute${numberEnding(minutes)}`
+    } else if (minutes) {
+      return `${minutes} minute${numberEnding(minutes)}`
+    } else if (seconds) {
+      return `${seconds} second${numberEnding(seconds)}`
+    }
+    return 'less than a second'
+  }
+
   async function getIndex (request: Hapi.Request, h: Hapi.ResponseToolkit) {
     const hostInfo: HostInfo = serverInfo(config, podManager, peerDb)
     const freeMemRaw = hostInfo.serverFreeMemory
@@ -21,8 +50,8 @@ export default function (server: Hapi.Server, deps: Injector) {
     return h.view('index', {
       uri: hostInfo.uri,
       numPeers: hostInfo.numPeers,
-      serverUptime: hostInfo.serverUptime,
-      serviceUptime: hostInfo.serviceUptime,
+      serverUptime: uptimeToStr(hostInfo.serverUptime),
+      serviceUptime: uptimeToStr(hostInfo.serviceUptime),
       avgLoad: hostInfo.avgLoad,
       currency: hostInfo.currency,
       costPerMonth: hostInfo.costPerMonth,


### PR DESCRIPTION
Quick note:

I opted to make custom code for this instead of using the `moment.duration.humanize()` method because it didn't provide a way to have add on days. E.G. I wasn't able to have `2 months 2 days`, just `2 months`. Just in case you were wondering.
