### PR TITLE
Add retryInterval wait after failed selfTest http

### DIFF
--- a/src/services/SelfTest.ts
+++ b/src/services/SelfTest.ts
@@ -126,6 +126,11 @@ export default class SelfTest {
             log.info('Codius Host Self Test successfully uploaded pod')
           } catch (err) {
             log.error('Error occurred while uploading self-test pod err=', err)
+            await new Promise(resolve => {
+                setTimeout(() => {
+                    resolve()
+                }, this.testConfig.retryInterval)
+            })
           }
           if (this.httpSuccess) {
             break

--- a/src/services/SelfTest.ts
+++ b/src/services/SelfTest.ts
@@ -127,9 +127,9 @@ export default class SelfTest {
           } catch (err) {
             log.error('Error occurred while uploading self-test pod err=', err)
             await new Promise(resolve => {
-                setTimeout(() => {
-                    resolve()
-                }, this.testConfig.retryInterval)
+              setTimeout(() => {
+                resolve()
+              }, this.testConfig.retryInterval)
             })
           }
           if (this.httpSuccess) {


### PR DESCRIPTION
Before, the code would just loop over immediately to retry HTTP selftest - this would give the pod inadequate time to start.