### PR TITLE
fix: stop discovering old peers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -800,9 +800,9 @@
       }
     },
     "cryptiles": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-4.1.1.tgz",
-      "integrity": "sha512-YuQUPbcOmaZsdvxJZ25DCA1W+lLIRoPJKBDKin+St1RCYEERSfoe1d25B1MvWNHN3e8SpFSVsqYvEUjp8J9H2w==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-4.1.3.tgz",
+      "integrity": "sha512-gT9nyTMSUC1JnziQpPbxKGBbUg8VL7Zn2NB4E1cJYvuXdElHrwxrV9bmltZGDzet45zSDGyYceueke1TjynGzw==",
       "requires": {
         "boom": "7.x.x"
       }
@@ -1906,13 +1906,21 @@
       "dev": true
     },
     "iron": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/iron/-/iron-5.0.4.tgz",
-      "integrity": "sha512-7iQ5/xFMIYaNt9g2oiNiWdhrOTdRUMFaWENUd0KghxwPUhrIH8DUY8FEyLNTTzf75jaII+jMexLdY/2HfV61RQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/iron/-/iron-5.0.6.tgz",
+      "integrity": "sha512-zYUMOSkEXGBdwlV/AXF9zJC0aLuTJUKHkGeYS5I2g225M5i6SrxQyGJGhPgOR8BK1omL6N5i6TcwfsXbP8/Exw==",
       "requires": {
+        "b64": "4.x.x",
         "boom": "7.x.x",
         "cryptiles": "4.x.x",
-        "hoek": "5.x.x"
+        "hoek": "6.x.x"
+      },
+      "dependencies": {
+        "hoek": {
+          "version": "6.1.2",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-6.1.2.tgz",
+          "integrity": "sha512-6qhh/wahGYZHFSFw12tBbJw5fsAhhwrrG/y3Cs0YMTv2WzMnL0oLPnQJjv1QJvEfylRSOFuP+xCu+tdx0tD16Q=="
+        }
       }
     },
     "is-arrayish": {
@@ -6141,16 +6149,33 @@
       "dev": true
     },
     "statehood": {
-      "version": "6.0.6",
-      "resolved": "https://registry.npmjs.org/statehood/-/statehood-6.0.6.tgz",
-      "integrity": "sha512-jR45n5ZMAkasw0xoE9j9TuLmJv4Sa3AkXe+6yIFT6a07kXYHgSbuD2OVGECdZGFxTmvNqLwL1iRIgvq6O6rq+A==",
+      "version": "6.0.8",
+      "resolved": "https://registry.npmjs.org/statehood/-/statehood-6.0.8.tgz",
+      "integrity": "sha512-/uk2Iq5VXCAGmYnRTjez6gDfU8fROm1Um5WH2C9aNCdG7DAqD94dqZgeuqXrvVFnfDqxAtorUBLUtD9El/uJ6w==",
       "requires": {
         "boom": "7.x.x",
         "bounce": "1.x.x",
         "cryptiles": "4.x.x",
-        "hoek": "5.x.x",
+        "hoek": "6.x.x",
         "iron": "5.x.x",
-        "joi": "13.x.x"
+        "joi": "14.x.x"
+      },
+      "dependencies": {
+        "hoek": {
+          "version": "6.1.2",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-6.1.2.tgz",
+          "integrity": "sha512-6qhh/wahGYZHFSFw12tBbJw5fsAhhwrrG/y3Cs0YMTv2WzMnL0oLPnQJjv1QJvEfylRSOFuP+xCu+tdx0tD16Q=="
+        },
+        "joi": {
+          "version": "14.3.0",
+          "resolved": "https://registry.npmjs.org/joi/-/joi-14.3.0.tgz",
+          "integrity": "sha512-0HKd1z8MWogez4GaU0LkY1FgW30vR2Kwy414GISfCU41OYgUC2GWpNe5amsvBZtDqPtt7DohykfOOMIw1Z5hvQ==",
+          "requires": {
+            "hoek": "6.x.x",
+            "isemail": "3.x.x",
+            "topo": "3.x.x"
+          }
+        }
       }
     },
     "statuses": {

--- a/src/services/PeerDatabase.ts
+++ b/src/services/PeerDatabase.ts
@@ -60,9 +60,6 @@ export default class PeerDatabase {
           if (process.env.NODE_ENV !== 'test') {
             log.trace('%s for %s', e, peer + '/info')
           }
-          if (e.response && e.response.status === 404) {
-            this.peers.add(peer)
-          }
         }
       }
     }

--- a/src/services/PeerFinder.ts
+++ b/src/services/PeerFinder.ts
@@ -28,7 +28,7 @@ export default class PeerFinder {
 
   async run () {
     if (this.selfTest.selfTestSuccess) {
-      log.debug('searching peers')
+      log.trace('searching peers')
       const queryPeers = sampleSize(this.peerDb.getPeers(), PEERS_PER_QUERY)
       log.trace('peers', queryPeers)
       for (const peer of queryPeers) {


### PR DESCRIPTION
This essentially reverts https://github.com/codius/codiusd/pull/65
Peers were repeatedly being added when returned in another peer's list and subsequently removed when we're unable to hit its `/peers/discover` endpoint.

This is in preparation for a major version bump, so we'll be especially less concerned about **old** peers that don't have the `/info` endpoint.